### PR TITLE
fix flattenSecurityAndAnalysis() to handle nil fields properly; tests

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -1023,13 +1023,23 @@ func flattenSecurityAndAnalysis(securityAndAnalysis *github.SecurityAndAnalysis)
 		}}
 	}
 
-	securityAndAnalysisMap["secret_scanning"] = []interface{}{map[string]interface{}{
-		"status": securityAndAnalysis.GetSecretScanning().GetStatus(),
-	}}
+	secretScanning := securityAndAnalysis.GetSecretScanning()
+	if secretScanning != nil && secretScanning.Status != nil {
+		securityAndAnalysisMap["secret_scanning"] = []interface{}{map[string]interface{}{
+			"status": secretScanning.GetStatus(),
+		}}
+	}
 
-	securityAndAnalysisMap["secret_scanning_push_protection"] = []interface{}{map[string]interface{}{
-		"status": securityAndAnalysis.GetSecretScanningPushProtection().GetStatus(),
-	}}
+	secretScanningPushProtection := securityAndAnalysis.GetSecretScanningPushProtection()
+	if secretScanningPushProtection != nil && secretScanningPushProtection.Status != nil {
+		securityAndAnalysisMap["secret_scanning_push_protection"] = []interface{}{map[string]interface{}{
+			"status": secretScanningPushProtection.GetStatus(),
+		}}
+	}
+
+	if len(securityAndAnalysisMap) == 0 {
+		return []interface{}{}
+	}
 
 	return []interface{}{securityAndAnalysisMap}
 }

--- a/github/resource_github_repository_security_test.go
+++ b/github/resource_github_repository_security_test.go
@@ -1,0 +1,105 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/v66/github"
+)
+
+func TestFlattenSecurityAndAnalysis(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *github.SecurityAndAnalysis
+		expected []interface{}
+	}{
+		{
+			name:     "nil input returns empty",
+			input:    nil,
+			expected: []interface{}{},
+		},
+		{
+			name: "empty SecurityAndAnalysis returns empty",
+			input: &github.SecurityAndAnalysis{},
+			expected: []interface{}{},
+		},
+		{
+			name: "only advanced security present",
+			input: &github.SecurityAndAnalysis{
+				AdvancedSecurity: &github.AdvancedSecurity{
+					Status: github.String("enabled"),
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"advanced_security": []interface{}{
+						map[string]interface{}{
+							"status": "enabled",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "all fields present",
+			input: &github.SecurityAndAnalysis{
+				AdvancedSecurity: &github.AdvancedSecurity{
+					Status: github.String("enabled"),
+				},
+				SecretScanning: &github.SecretScanning{
+					Status: github.String("enabled"),
+				},
+				SecretScanningPushProtection: &github.SecretScanningPushProtection{
+					Status: github.String("enabled"),
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"advanced_security": []interface{}{
+						map[string]interface{}{
+							"status": "enabled",
+						},
+					},
+					"secret_scanning": []interface{}{
+						map[string]interface{}{
+							"status": "enabled",
+						},
+					},
+					"secret_scanning_push_protection": []interface{}{
+						map[string]interface{}{
+							"status": "enabled",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "secret scanning fields with nil status are omitted",
+			input: &github.SecurityAndAnalysis{
+				AdvancedSecurity: &github.AdvancedSecurity{
+					Status: github.String("disabled"),
+				},
+				SecretScanning:               &github.SecretScanning{},
+				SecretScanningPushProtection: &github.SecretScanningPushProtection{},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"advanced_security": []interface{}{
+						map[string]interface{}{
+							"status": "disabled",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := flattenSecurityAndAnalysis(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("flattenSecurityAndAnalysis() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request improves the handling and testing of the `flattenSecurityAndAnalysis` function in the GitHub repository resource code. The main changes ensure that secret scanning fields are only included if their status is set, and introduce comprehensive unit tests to verify correct behavior for various input scenarios.

### Improvements to security and analysis flattening logic

* Updated `flattenSecurityAndAnalysis` in `github/resource_github_repository.go` to only add `secret_scanning` and `secret_scanning_push_protection` fields to the output if their `Status` is not nil, preventing empty or incomplete data from being included. Also, the function now returns an empty slice when no fields are present.

### Testing enhancements

* Added new unit tests in `github/resource_github_repository_security_test.go` to cover multiple scenarios for `flattenSecurityAndAnalysis`, including cases with nil input, empty structs, and combinations of advanced security and secret scanning fields. This ensures the function behaves correctly for all expected inputs.