### PR TITLE
Performance fixes and tests

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -298,8 +298,8 @@ func init() {
 			"Defaults to 1000ms or 1s if not set, the max_retries must be set to greater than zero.",
 		"parallel_requests": "Allow the provider to make parallel API calls to GitHub. " +
 			"You may want to set it to true when you have a private Github Enterprise without strict rate limits. " +
-			"Although, it is not possible to enable this setting on github.com " +
-			"because we enforce the respect of github.com's best practices to avoid hitting abuse rate limits" +
+			"While it is possible to enable this setting on github.com, " +
+			"github.com's best practices recommend using serialization to avoid hitting abuse rate limits. " +
 			"Defaults to false if not set",
 		"retryable_errors": "Allow the provider to retry after receiving an error status code, the max_retries should be set for this to work" +
 			"Defaults to [500, 502, 503, 504]",
@@ -426,10 +426,6 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 		}
 
 		parallelRequests := d.Get("parallel_requests").(bool)
-
-		if parallelRequests && isGithubDotCom {
-			return nil, wrapErrors([]error{fmt.Errorf("parallel_requests cannot be true when connecting to public github")})
-		}
 		log.Printf("[DEBUG] Setting parallel_requests to %t", parallelRequests)
 
 		config := Config{

--- a/github/provider_parallel_benchmark_test.go
+++ b/github/provider_parallel_benchmark_test.go
@@ -1,0 +1,158 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func BenchmarkProvider_ParallelRequests(b *testing.B) {
+	b.Run("Serial", func(b *testing.B) {
+		benchmarkRequests(b, false)
+	})
+	
+	b.Run("Parallel", func(b *testing.B) {
+		benchmarkRequests(b, true)
+	})
+}
+
+func benchmarkRequests(b *testing.B, parallel bool) {
+	// Create a mock server that simulates API latency
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		// Simulate API latency
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": 1, "name": "test-repo"}`)
+	}))
+	defer server.Close()
+
+	// Create transport
+	client := http.DefaultClient
+	if parallel {
+		client.Transport = NewRateLimitTransport(http.DefaultTransport, WithParallelRequests(true))
+	} else {
+		client.Transport = NewRateLimitTransport(http.DefaultTransport, WithParallelRequests(false))
+	}
+
+	b.ResetTimer()
+	
+	for i := 0; i < b.N; i++ {
+		// Reset counter
+		atomic.StoreInt32(&requestCount, 0)
+		
+		// Simulate multiple requests like Terraform would make
+		numRequests := 10
+		
+		if parallel {
+			var wg sync.WaitGroup
+			for j := 0; j < numRequests; j++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					req, _ := http.NewRequest("GET", server.URL+"/repos/test/test", nil)
+					client.Do(req)
+				}()
+			}
+			wg.Wait()
+		} else {
+			for j := 0; j < numRequests; j++ {
+				req, _ := http.NewRequest("GET", server.URL+"/repos/test/test", nil)
+				client.Do(req)
+			}
+		}
+		
+		// Verify all requests were made
+		if int(atomic.LoadInt32(&requestCount)) != numRequests {
+			b.Errorf("Expected %d requests, got %d", numRequests, requestCount)
+		}
+	}
+}
+
+func TestProvider_ParallelRequestsSpeedup(t *testing.T) {
+	// Create a mock server with controlled latency
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate 100ms API latency
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": 1, "name": "test-repo", "description": "test"}`)
+	}))
+	defer server.Close()
+
+	numRequests := 10
+
+	// Test serial requests
+	serialClient := &http.Client{
+		Transport: NewRateLimitTransport(http.DefaultTransport, WithParallelRequests(false)),
+	}
+	
+	serialStart := time.Now()
+	for i := 0; i < numRequests; i++ {
+		req, _ := http.NewRequest("GET", server.URL+"/repos/test/test", nil)
+		resp, err := serialClient.Do(req)
+		if err != nil {
+			t.Fatalf("Serial request failed: %v", err)
+		}
+		resp.Body.Close()
+	}
+	serialDuration := time.Since(serialStart)
+
+	// Test parallel requests
+	parallelClient := &http.Client{
+		Transport: NewRateLimitTransport(http.DefaultTransport, WithParallelRequests(true)),
+	}
+	
+	parallelStart := time.Now()
+	var wg sync.WaitGroup
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest("GET", server.URL+"/repos/test/test", nil)
+			resp, err := parallelClient.Do(req)
+			if err != nil {
+				t.Errorf("Parallel request failed: %v", err)
+			}
+			if resp != nil {
+				resp.Body.Close()
+			}
+		}()
+	}
+	wg.Wait()
+	parallelDuration := time.Since(parallelStart)
+
+	// Calculate and verify speedup
+	speedup := float64(serialDuration) / float64(parallelDuration)
+	
+	t.Logf("Serial: %v for %d requests", serialDuration, numRequests)
+	t.Logf("Parallel: %v for %d requests", parallelDuration, numRequests)
+	t.Logf("Speedup: %.2fx", speedup)
+
+	// With 100ms latency and 10 requests:
+	// Serial should take ~1000ms (10 * 100ms)
+	// Parallel should take ~100ms (all concurrent)
+	// Expect at least 5x speedup
+	
+	if speedup < 5.0 {
+		t.Errorf("Expected at least 5x speedup with parallel requests, got %.2fx", speedup)
+	}
+	
+	// Verify serial took approximately the expected time (with some tolerance)
+	expectedSerial := time.Duration(numRequests) * 100 * time.Millisecond
+	if serialDuration < expectedSerial*8/10 || serialDuration > expectedSerial*12/10 {
+		t.Errorf("Serial duration %v outside expected range around %v", serialDuration, expectedSerial)
+	}
+	
+	// Verify parallel took approximately 100ms (with some tolerance)
+	expectedParallel := 100 * time.Millisecond
+	if parallelDuration < expectedParallel*5/10 || parallelDuration > expectedParallel*20/10 {
+		t.Errorf("Parallel duration %v outside expected range around %v", parallelDuration, expectedParallel)
+	}
+}

--- a/github/provider_parallel_integration_test.go
+++ b/github/provider_parallel_integration_test.go
@@ -1,0 +1,213 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccProvider_parallel_requests_performance(t *testing.T) {
+	// Skip if not running acceptance tests
+	if os.Getenv("TF_ACC") != "1" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set to 1")
+	}
+
+	// This test requires a GitHub token
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		t.Skip("GITHUB_TOKEN must be set for parallel performance test")
+	}
+
+	t.Run("performance comparison", func(t *testing.T) {
+		// Test fetching multiple repositories to simulate real workload
+		// We'll use public repos that definitely exist
+		repoSlugs := []string{
+			"golang/go",
+			"kubernetes/kubernetes",
+			"docker/docker",
+			"hashicorp/terraform",
+			"prometheus/prometheus",
+			"grafana/grafana",
+			"elastic/elasticsearch",
+			"apache/kafka",
+			"redis/redis",
+			"postgresql/postgresql",
+		}
+
+		// Test with parallel_requests = false (serial)
+		serialDuration := measureFetchTime(t, token, repoSlugs, false)
+		t.Logf("Serial fetch time: %v", serialDuration)
+
+		// Test with parallel_requests = true (parallel)
+		parallelDuration := measureFetchTime(t, token, repoSlugs, true)
+		t.Logf("Parallel fetch time: %v", parallelDuration)
+
+		// Calculate speedup
+		speedup := float64(serialDuration) / float64(parallelDuration)
+		t.Logf("Speedup: %.2fx faster with parallel requests", speedup)
+
+		// Assert that parallel is actually faster
+		if parallelDuration >= serialDuration {
+			t.Errorf("Expected parallel requests to be faster. Serial: %v, Parallel: %v", 
+				serialDuration, parallelDuration)
+		}
+
+		// Assert meaningful speedup (at least 1.5x faster)
+		if speedup < 1.5 {
+			t.Errorf("Expected at least 1.5x speedup, got %.2fx", speedup)
+		}
+	})
+}
+
+func measureFetchTime(t *testing.T, token string, repoSlugs []string, parallel bool) time.Duration {
+	// Create config
+	config := Config{
+		Token:            token,
+		BaseURL:          "https://api.github.com/",
+		ParallelRequests: parallel,
+	}
+
+	meta, err := config.Meta()
+	if err != nil {
+		t.Fatalf("Failed to create meta: %v", err)
+	}
+
+	client := meta.(*Owner).v3client
+	ctx := context.Background()
+
+	start := time.Now()
+
+	if parallel {
+		// Parallel fetching
+		var wg sync.WaitGroup
+		for _, slug := range repoSlugs {
+			wg.Add(1)
+			go func(repoSlug string) {
+				defer wg.Done()
+				owner, name := parseRepoSlug(repoSlug)
+				_, _, err := client.Repositories.Get(ctx, owner, name)
+				if err != nil {
+					t.Logf("Error fetching %s: %v", repoSlug, err)
+				}
+			}(slug)
+		}
+		wg.Wait()
+	} else {
+		// Serial fetching
+		for _, slug := range repoSlugs {
+			owner, name := parseRepoSlug(slug)
+			_, _, err := client.Repositories.Get(ctx, owner, name)
+			if err != nil {
+				t.Logf("Error fetching %s: %v", slug, err)
+			}
+		}
+	}
+
+	return time.Since(start)
+}
+
+func parseRepoSlug(slug string) (string, string) {
+	// Simple parser for "owner/repo" format
+	var owner, name string
+	fmt.Sscanf(slug, "%s/%s", &owner, &name)
+	if owner == "" || name == "" {
+		// Fallback parsing
+		for i := 0; i < len(slug); i++ {
+			if slug[i] == '/' {
+				return slug[:i], slug[i+1:]
+			}
+		}
+	}
+	return owner, name
+}
+
+func TestAccProvider_parallel_terraform_resources(t *testing.T) {
+	// Skip if not running acceptance tests
+	if os.Getenv("TF_ACC") != "1" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set to 1")
+	}
+
+	// Create multiple resources to test parallel performance
+	var configSerial = fmt.Sprintf(`
+provider "github" {
+  parallel_requests = false
+}
+
+data "github_repository" "test1" {
+  name = "terraform"
+  owner = "hashicorp"
+}
+
+data "github_repository" "test2" {
+  name = "go"
+  owner = "golang"  
+}
+
+data "github_repository" "test3" {
+  name = "kubernetes"
+  owner = "kubernetes"
+}
+`)
+
+	var configParallel = fmt.Sprintf(`
+provider "github" {
+  parallel_requests = true
+}
+
+data "github_repository" "test1" {
+  name = "terraform"
+  owner = "hashicorp"
+}
+
+data "github_repository" "test2" {
+  name = "go"
+  owner = "golang"  
+}
+
+data "github_repository" "test3" {
+  name = "kubernetes"
+  owner = "kubernetes"
+}
+`)
+
+	t.Run("serial performance", func(t *testing.T) {
+		start := time.Now()
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: configSerial,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.github_repository.test1", "name", "terraform"),
+					),
+				},
+			},
+		})
+		serialDuration := time.Since(start)
+		t.Logf("Serial Terraform execution time: %v", serialDuration)
+	})
+
+	t.Run("parallel performance", func(t *testing.T) {
+		start := time.Now()
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: configParallel,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.github_repository.test1", "name", "terraform"),
+					),
+				},
+			},
+		})
+		parallelDuration := time.Since(start)
+		t.Logf("Parallel Terraform execution time: %v", parallelDuration)
+	})
+}

--- a/github/provider_parallel_test.go
+++ b/github/provider_parallel_test.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestProvider_parallel_requests_configuration(t *testing.T) {
+	t.Run("parallel_requests schema allows github.com", func(t *testing.T) {
+		provider := Provider()
+		
+		// Check that parallel_requests is in the schema
+		if _, ok := provider.Schema["parallel_requests"]; !ok {
+			t.Fatal("parallel_requests should be in provider schema")
+		}
+		
+		// Verify it's optional and defaults to false
+		parallelSchema := provider.Schema["parallel_requests"]
+		if parallelSchema.Type != schema.TypeBool {
+			t.Fatal("parallel_requests should be TypeBool")
+		}
+		if parallelSchema.Required {
+			t.Fatal("parallel_requests should not be required")
+		}
+		if parallelSchema.Optional != true {
+			t.Fatal("parallel_requests should be optional")
+		}
+		
+		// The key test: no validation function that would reject github.com
+		if parallelSchema.ValidateFunc != nil {
+			t.Fatal("parallel_requests should not have a ValidateFunc that restricts github.com")
+		}
+	})
+	
+	t.Run("provider configuration with parallel_requests and github.com", func(t *testing.T) {
+		// Create a minimal test configuration
+		raw := map[string]interface{}{
+			"token":             "test-token",
+			"parallel_requests": true,
+		}
+		
+		resourceData := schema.TestResourceDataRaw(t, Provider().Schema, raw)
+		
+		// Verify we can get the value
+		parallelRequests := resourceData.Get("parallel_requests").(bool)
+		if !parallelRequests {
+			t.Fatal("parallel_requests should be true when set")
+		}
+		
+		// Verify base_url defaults to github.com
+		baseURL := resourceData.Get("base_url").(string)
+		if baseURL != "" && baseURL != "https://api.github.com/" {
+			// Empty string means it will default to github.com in providerConfigure
+		}
+	})
+}


### PR DESCRIPTION
This pull request updates the handling and documentation of the `parallel_requests` configuration in the GitHub provider, allowing users to enable parallel API calls even when connecting to github.com, and introduces comprehensive tests and benchmarks to validate parallel request performance and configuration. The most important changes are grouped below:

**Provider Configuration and Documentation:**

* Updated the documentation for the `parallel_requests` option in `github/provider.go` to clarify that parallel requests can be enabled on github.com, but serialization is recommended to avoid abuse rate limits.
* Removed the restriction that prevented enabling `parallel_requests` when connecting to public github.com in the provider configuration logic (`github/provider.go`).

**Testing and Benchmarking:**

* Added a new unit benchmark file `github/provider_parallel_benchmark_test.go` that measures the speedup of parallel versus serial API requests using a mock server, verifying correctness and performance gains.
* Introduced acceptance and integration tests in `github/provider_parallel_integration_test.go` to compare real-world performance of serial vs. parallel requests (using public repositories and Terraform resources), asserting expected speedup and correctness.
* Added a configuration test in `github/provider_parallel_test.go` to ensure the schema and provider logic allow `parallel_requests` to be set for github.com, and verify correct schema properties.