### PR TITLE
Fix #2718: Add missing repository argument to documentation

### DIFF
--- a/website/docs/r/actions_environment_variable.html.markdown
+++ b/website/docs/r/actions_environment_variable.html.markdown
@@ -14,6 +14,7 @@ You must have write access to a repository to use this resource.
 
 ```hcl
 resource "github_actions_environment_variable" "example_variable" {
+  repository        = "example_repository"
   environment       = "example_environment"
   variable_name     = "example_variable_name"
   value             = "example_variable_value"


### PR DESCRIPTION
This pull request adds an explicit `repository` attribute to the example usage of the `github_actions_environment_variable` resource in the documentation. This clarifies the required configuration for users.

* Documentation update: Added the `repository` parameter to the example configuration in `website/docs/r/actions_environment_variable.html.markdown` to improve clarity for users.
