### PR TITLE
docs: add agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+## Environment
+
+### Setup script
+
+```bash
+go install golang.org/dl/go1.22.0@latest
+go1.22.0 download
+export GOTOOLCHAIN=go1.22.0
+export PATH="$PATH:$(go env GOPATH)/bin"
+make tools
+```
+
+### Maintenance script
+
+```bash
+export GOTOOLCHAIN=go1.22.0
+export PATH="$PATH:$(go env GOPATH)/bin"
+make tools
+```
+
+## Build
+
+- Build all packages: `go build ./...`
+
+## Testing
+
+- Run unit tests: `make test`
+- Run acceptance tests (require GitHub credentials):
+  ```bash
+  export GITHUB_TOKEN=<token>
+  export GITHUB_ORGANIZATION=<org>
+  make testacc
+  ```
+
+## Lint
+
+- Run linter: `make lint`
+  - The linter may report existing issues.
+
+## Code style
+
+- Format code: `make fmt`
+- Verify formatting: `make fmtcheck`


### PR DESCRIPTION
## Summary
- document Go bin path setup for tools
- recommend `make test`/`make testacc` for unit and acceptance tests
- note `make lint` may report existing issues

## Testing
- `prettier --write AGENTS.md`
- `make tools`
- `go build ./...`
- `make test`
- `make fmtcheck` *(fails: gofmt needs running)*
- `make lint` *(fails: errcheck, gofmt, gosimple, staticcheck errors)*
- `make testacc` *(fails: gofmt needs running)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cee92a988326822b18d7bc348417