### PR TITLE
Fix lint issues in parallel tests

### DIFF
--- a/github/provider_parallel_benchmark_test.go
+++ b/github/provider_parallel_benchmark_test.go
@@ -14,7 +14,7 @@ func BenchmarkProvider_ParallelRequests(b *testing.B) {
 	b.Run("Serial", func(b *testing.B) {
 		benchmarkRequests(b, false)
 	})
-	
+
 	b.Run("Parallel", func(b *testing.B) {
 		benchmarkRequests(b, true)
 	})
@@ -42,14 +42,14 @@ func benchmarkRequests(b *testing.B, parallel bool) {
 	}
 
 	b.ResetTimer()
-	
+
 	for i := 0; i < b.N; i++ {
 		// Reset counter
 		atomic.StoreInt32(&requestCount, 0)
-		
+
 		// Simulate multiple requests like Terraform would make
 		numRequests := 10
-		
+
 		if parallel {
 			var wg sync.WaitGroup
 			for j := 0; j < numRequests; j++ {
@@ -57,17 +57,27 @@ func benchmarkRequests(b *testing.B, parallel bool) {
 				go func() {
 					defer wg.Done()
 					req, _ := http.NewRequest("GET", server.URL+"/repos/test/test", nil)
-					client.Do(req)
+					resp, err := client.Do(req)
+					if err != nil {
+						b.Errorf("request failed: %v", err)
+						return
+					}
+					resp.Body.Close()
 				}()
 			}
 			wg.Wait()
 		} else {
 			for j := 0; j < numRequests; j++ {
 				req, _ := http.NewRequest("GET", server.URL+"/repos/test/test", nil)
-				client.Do(req)
+				resp, err := client.Do(req)
+				if err != nil {
+					b.Errorf("request failed: %v", err)
+					continue
+				}
+				resp.Body.Close()
 			}
 		}
-		
+
 		// Verify all requests were made
 		if int(atomic.LoadInt32(&requestCount)) != numRequests {
 			b.Errorf("Expected %d requests, got %d", numRequests, requestCount)
@@ -92,7 +102,7 @@ func TestProvider_ParallelRequestsSpeedup(t *testing.T) {
 	serialClient := &http.Client{
 		Transport: NewRateLimitTransport(http.DefaultTransport, WithParallelRequests(false)),
 	}
-	
+
 	serialStart := time.Now()
 	for i := 0; i < numRequests; i++ {
 		req, _ := http.NewRequest("GET", server.URL+"/repos/test/test", nil)
@@ -108,7 +118,7 @@ func TestProvider_ParallelRequestsSpeedup(t *testing.T) {
 	parallelClient := &http.Client{
 		Transport: NewRateLimitTransport(http.DefaultTransport, WithParallelRequests(true)),
 	}
-	
+
 	parallelStart := time.Now()
 	var wg sync.WaitGroup
 	for i := 0; i < numRequests; i++ {
@@ -130,7 +140,7 @@ func TestProvider_ParallelRequestsSpeedup(t *testing.T) {
 
 	// Calculate and verify speedup
 	speedup := float64(serialDuration) / float64(parallelDuration)
-	
+
 	t.Logf("Serial: %v for %d requests", serialDuration, numRequests)
 	t.Logf("Parallel: %v for %d requests", parallelDuration, numRequests)
 	t.Logf("Speedup: %.2fx", speedup)
@@ -139,17 +149,17 @@ func TestProvider_ParallelRequestsSpeedup(t *testing.T) {
 	// Serial should take ~1000ms (10 * 100ms)
 	// Parallel should take ~100ms (all concurrent)
 	// Expect at least 5x speedup
-	
+
 	if speedup < 5.0 {
 		t.Errorf("Expected at least 5x speedup with parallel requests, got %.2fx", speedup)
 	}
-	
+
 	// Verify serial took approximately the expected time (with some tolerance)
 	expectedSerial := time.Duration(numRequests) * 100 * time.Millisecond
 	if serialDuration < expectedSerial*8/10 || serialDuration > expectedSerial*12/10 {
 		t.Errorf("Serial duration %v outside expected range around %v", serialDuration, expectedSerial)
 	}
-	
+
 	// Verify parallel took approximately 100ms (with some tolerance)
 	expectedParallel := 100 * time.Millisecond
 	if parallelDuration < expectedParallel*5/10 || parallelDuration > expectedParallel*20/10 {

--- a/github/provider_parallel_integration_test.go
+++ b/github/provider_parallel_integration_test.go
@@ -53,7 +53,7 @@ func TestAccProvider_parallel_requests_performance(t *testing.T) {
 
 		// Assert that parallel is actually faster
 		if parallelDuration >= serialDuration {
-			t.Errorf("Expected parallel requests to be faster. Serial: %v, Parallel: %v", 
+			t.Errorf("Expected parallel requests to be faster. Serial: %v, Parallel: %v",
 				serialDuration, parallelDuration)
 		}
 
@@ -133,7 +133,7 @@ func TestAccProvider_parallel_terraform_resources(t *testing.T) {
 	}
 
 	// Create multiple resources to test parallel performance
-	var configSerial = fmt.Sprintf(`
+	const configSerial = `
 provider "github" {
   parallel_requests = false
 }
@@ -145,16 +145,16 @@ data "github_repository" "test1" {
 
 data "github_repository" "test2" {
   name = "go"
-  owner = "golang"  
+  owner = "golang"
 }
 
 data "github_repository" "test3" {
   name = "kubernetes"
   owner = "kubernetes"
 }
-`)
+`
 
-	var configParallel = fmt.Sprintf(`
+	const configParallel = `
 provider "github" {
   parallel_requests = true
 }
@@ -166,14 +166,14 @@ data "github_repository" "test1" {
 
 data "github_repository" "test2" {
   name = "go"
-  owner = "golang"  
+  owner = "golang"
 }
 
 data "github_repository" "test3" {
   name = "kubernetes"
   owner = "kubernetes"
 }
-`)
+`
 
 	t.Run("serial performance", func(t *testing.T) {
 		start := time.Now()

--- a/github/provider_parallel_test.go
+++ b/github/provider_parallel_test.go
@@ -9,12 +9,12 @@ import (
 func TestProvider_parallel_requests_configuration(t *testing.T) {
 	t.Run("parallel_requests schema allows github.com", func(t *testing.T) {
 		provider := Provider()
-		
+
 		// Check that parallel_requests is in the schema
 		if _, ok := provider.Schema["parallel_requests"]; !ok {
 			t.Fatal("parallel_requests should be in provider schema")
 		}
-		
+
 		// Verify it's optional and defaults to false
 		parallelSchema := provider.Schema["parallel_requests"]
 		if parallelSchema.Type != schema.TypeBool {
@@ -26,32 +26,32 @@ func TestProvider_parallel_requests_configuration(t *testing.T) {
 		if parallelSchema.Optional != true {
 			t.Fatal("parallel_requests should be optional")
 		}
-		
+
 		// The key test: no validation function that would reject github.com
 		if parallelSchema.ValidateFunc != nil {
 			t.Fatal("parallel_requests should not have a ValidateFunc that restricts github.com")
 		}
 	})
-	
+
 	t.Run("provider configuration with parallel_requests and github.com", func(t *testing.T) {
 		// Create a minimal test configuration
 		raw := map[string]interface{}{
 			"token":             "test-token",
 			"parallel_requests": true,
 		}
-		
+
 		resourceData := schema.TestResourceDataRaw(t, Provider().Schema, raw)
-		
+
 		// Verify we can get the value
 		parallelRequests := resourceData.Get("parallel_requests").(bool)
 		if !parallelRequests {
 			t.Fatal("parallel_requests should be true when set")
 		}
-		
+
 		// Verify base_url defaults to github.com
 		baseURL := resourceData.Get("base_url").(string)
 		if baseURL != "" && baseURL != "https://api.github.com/" {
-			// Empty string means it will default to github.com in providerConfigure
+			t.Fatalf("base_url should be empty or %q, got %q", "https://api.github.com/", baseURL)
 		}
 	})
 }

--- a/github/resource_github_repository_security_test.go
+++ b/github/resource_github_repository_security_test.go
@@ -19,8 +19,8 @@ func TestFlattenSecurityAndAnalysis(t *testing.T) {
 			expected: []interface{}{},
 		},
 		{
-			name: "empty SecurityAndAnalysis returns empty",
-			input: &github.SecurityAndAnalysis{},
+			name:     "empty SecurityAndAnalysis returns empty",
+			input:    &github.SecurityAndAnalysis{},
 			expected: []interface{}{},
 		},
 		{


### PR DESCRIPTION
## Summary
- add error handling for HTTP calls in parallel benchmark
- use raw string configs instead of fmt.Sprintf in parallel integration test
- validate base URL to avoid empty branch in provider test
- format security tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0aeb399c8326b37ae3ea7b731cb0